### PR TITLE
Enforce mandatory OpenAI layout generation

### DIFF
--- a/streamdeck_profile_generator/__init__.py
+++ b/streamdeck_profile_generator/__init__.py
@@ -1,0 +1,11 @@
+"""Stream Deck profile generator package."""
+
+from .layout import LayoutGenerationError
+from .models import Button, Page, Profile
+
+__all__ = [
+    "Button",
+    "Page",
+    "Profile",
+    "LayoutGenerationError",
+]

--- a/streamdeck_profile_generator/cli.py
+++ b/streamdeck_profile_generator/cli.py
@@ -1,0 +1,62 @@
+"""Command line entry-point for Stream Deck profile generation."""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+from typing import Optional
+
+from .layout import build_profile_pages
+from .models import Profile
+from .packaging import create_streamdeck_profile
+
+
+def generate_profile(software_title: str) -> Profile:
+    """Generate a profile for the supplied software title."""
+
+    pages = build_profile_pages(software_title)
+    return Profile(software_title=software_title, pages=pages)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point used by `python -m streamdeck_profile_generator.cli`."""
+
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if argv:
+        software = " ".join(argv).strip()
+    else:
+        try:
+            software = input("Software title: ").strip()
+        except EOFError:
+            software = ""
+
+    if not software:
+        print("Aborted: no software title provided.")
+        return 1
+
+    try:
+        print(f"Generating StreamDeck profile for: {software}")
+        profile = generate_profile(software)
+        print(f"Profile generated with {len(profile.pages)} page(s)")
+
+        output_basename = os.path.abspath(software.replace(" ", "_") + "_XL")
+        print(f"Creating profile file: {output_basename}.streamDeckProfile")
+
+        archive = create_streamdeck_profile(profile, output_basename)
+        print(f"✅ SUCCESS: Generated StreamDeck Profile: {archive}")
+        print("📁 Import this .streamDeckProfile file into Stream Deck software.")
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive CLI logging
+        print("❌ ERROR: Failed to generate Stream Deck profile.")
+        print("--- Recursive traceback (most recent call last) ---")
+        for line in traceback.TracebackException.from_exception(exc).format(chain=True):
+            print(line, end="")
+        print("--- End traceback ---")
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI behavior
+    raise SystemExit(main())

--- a/streamdeck_profile_generator/fallback.py
+++ b/streamdeck_profile_generator/fallback.py
@@ -1,0 +1,101 @@
+"""Deterministic fallback layout for Stream Deck profiles."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .models import BUTTONS_PER_PAGE, GRID_COLS, Button, Page
+
+
+def build_default_pages() -> List[Page]:
+    """Return a minimal multi-page layout when OpenAI is unavailable."""
+
+    pages: List[Page] = []
+
+    master_buttons = [
+        Button(0, 0, "Combat", "switch_page:Combat"),
+        Button(1, 0, "Inventory", "switch_page:Inventory"),
+        Button(2, 0, "Map", "switch_page:Map"),
+        Button(3, 0, "Quests", "switch_page:Quests"),
+        Button(4, 0, "Settings", "switch_page:Settings"),
+        Button(5, 0, "Shortcuts", "switch_page:Shortcuts"),
+        Button(6, 0, "Help", "switch_page:Help"),
+        Button(7, 3, "Default", "profile:Default"),
+    ]
+
+    master_buttons.extend(_fill_remaining_slots(master_buttons))
+    pages.append(Page("Master", master_buttons))
+
+    combat_buttons = [
+        Button(0, 0, "Space", "hotkey:Space"),
+        Button(1, 0, "Group", "hotkey:G"),
+        Button(2, 0, "Hide", "hotkey:H"),
+        Button(3, 0, "Sneak", "hotkey:C"),
+        Button(4, 0, "Shove", "hotkey:R"),
+        Button(5, 0, "Throw", "hotkey:T"),
+        Button(6, 0, "End Turn", "hotkey:Enter"),
+        Button(7, 0, "Highlight", "hotkey:Tab"),
+        Button(0, 1, "Select 1", "hotkey:1"),
+        Button(1, 1, "Select 2", "hotkey:2"),
+        Button(2, 1, "Select 3", "hotkey:3"),
+        Button(3, 1, "Select 4", "hotkey:4"),
+        Button(4, 1, "Center 1", "hotkey:F1"),
+        Button(5, 1, "Center 2", "hotkey:F2"),
+        Button(6, 1, "Center 3", "hotkey:F3"),
+        Button(7, 1, "Center 4", "hotkey:F4"),
+        Button(0, 3, "RTB", "switch_page:Master"),
+    ]
+
+    combat_buttons.extend(_fill_remaining_slots(combat_buttons, include_master_controls=False))
+    pages.append(Page("Combat", combat_buttons))
+
+    inventory_buttons = [
+        Button(0, 0, "Inventory", "hotkey:I"),
+        Button(1, 0, "Spellbook", "hotkey:B"),
+        Button(2, 0, "Character", "hotkey:K"),
+        Button(3, 0, "Journal", "hotkey:L"),
+        Button(4, 0, "Interact", "hotkey:F"),
+        Button(5, 0, "Examine", "hotkey:E"),
+        Button(6, 0, "Quick Save", "hotkey:F5"),
+        Button(7, 0, "Quick Load", "hotkey:F8"),
+        Button(0, 3, "RTB", "switch_page:Master"),
+    ]
+
+    inventory_buttons.extend(_fill_remaining_slots(inventory_buttons, include_master_controls=False))
+    pages.append(Page("Inventory", inventory_buttons))
+
+    map_buttons = [
+        Button(0, 0, "Map", "hotkey:M"),
+        Button(1, 0, "Screenshot", "hotkey:F10"),
+        Button(2, 0, "Fullscreen", "hotkey:F11"),
+        Button(3, 0, "Menu", "hotkey:Esc"),
+        Button(0, 3, "RTB", "switch_page:Master"),
+    ]
+
+    map_buttons.extend(_fill_remaining_slots(map_buttons, include_master_controls=False))
+    pages.append(Page("Map", map_buttons))
+
+    return pages
+
+
+def _fill_remaining_slots(existing: List[Button], include_master_controls: bool = True) -> List[Button]:
+    """Pad a page with placeholder buttons while respecting RTB/default rules."""
+
+    grid = {(button.col, button.row) for button in existing}
+    placeholders: List[Button] = []
+
+    for idx in range(BUTTONS_PER_PAGE):
+        col = idx % GRID_COLS
+        row = idx // GRID_COLS
+
+        if (col, row) in grid:
+            continue
+
+        if include_master_controls and col == 7 and row == 3:
+            placeholders.append(Button(col, row, "Default", "profile:Default"))
+        elif not include_master_controls and col == 0 and row == 3:
+            placeholders.append(Button(col, row, "RTB", "switch_page:Master"))
+        else:
+            placeholders.append(Button(col, row, "—", "noop"))
+
+    return placeholders

--- a/streamdeck_profile_generator/icons.py
+++ b/streamdeck_profile_generator/icons.py
@@ -1,0 +1,81 @@
+"""Icon rendering helpers for Stream Deck profiles."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+from .models import Page
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except Exception:  # pragma: no cover - optional dependency
+    Image = None
+    ImageDraw = None
+    ImageFont = None
+
+
+def render_icons(pages: Iterable[Page], outdir: str) -> None:
+    """Render simple text icons for all non-empty buttons."""
+
+    if Image is None:
+        return
+
+    os.makedirs(outdir, exist_ok=True)
+    width, height = 144, 144
+    bg = (24, 24, 28)
+    fg = (235, 235, 245)
+
+    try:
+        font = ImageFont.truetype("arial.ttf", 28)
+    except Exception:
+        try:
+            font = ImageFont.truetype("DejaVuSans.ttf", 28)
+        except Exception:
+            font = ImageFont.load_default()
+
+    for page in pages:
+        for button in page.buttons:
+            if button.title == "—" or button.action == "noop":
+                continue
+
+            text = button.title or ""
+            image = Image.new("RGB", (width, height), bg)
+            draw = ImageDraw.Draw(image)
+            draw.rounded_rectangle([(2, 2), (width - 3, height - 3)], radius=18, outline=(80, 80, 90), width=3)
+
+            wrapped: list[str] = []
+            for piece in text.replace("\n", " ").split():
+                if not wrapped:
+                    wrapped.append(piece)
+                else:
+                    candidate = f"{wrapped[-1]} {piece}"
+                    if draw.textlength(candidate, font=font) <= width - 24:
+                        wrapped[-1] = candidate
+                    else:
+                        wrapped.append(piece)
+                if len(wrapped) == 3:
+                    break
+
+            line_height = int(font.size * 1.1)
+            block_height = len(wrapped) * line_height
+            y_pos = (height - block_height) // 2
+            for line in wrapped:
+                text_width = draw.textlength(line, font=font)
+                x_pos = (width - text_width) // 2
+                draw.text((x_pos, y_pos), line, fill=fg, font=font)
+                y_pos += line_height
+
+            icon_name = f"{_random_icon_name()}.png"
+            image.save(os.path.join(outdir, icon_name), "PNG")
+            button.icon = icon_name
+
+
+def _random_icon_name(length: int = 27) -> str:
+    """Generate a pseudo-random icon filename that mirrors Stream Deck IDs."""
+
+    import random
+    import string
+
+    characters = string.ascii_uppercase + string.digits
+    return "".join(random.choice(characters) for _ in range(length))

--- a/streamdeck_profile_generator/layout.py
+++ b/streamdeck_profile_generator/layout.py
@@ -1,0 +1,138 @@
+"""Layout planning utilities for Stream Deck profile generation."""
+
+from __future__ import annotations
+
+import json
+import os
+import textwrap
+from typing import Any, Dict, List, cast
+
+try:
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None
+
+from .models import BUTTONS_PER_PAGE, GRID_COLS, GRID_ROWS, Button, Page
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class LayoutGenerationError(RuntimeError):
+    """Raised when an AI powered layout cannot be produced."""
+
+
+# ---------------------------------------------------------------------------
+# OpenAI helpers
+# ---------------------------------------------------------------------------
+
+def _build_openai_client() -> "OpenAI":
+    """Create an OpenAI client or raise a detailed error."""
+
+    if OpenAI is None:
+        raise LayoutGenerationError(
+            "openai package is not installed; install `openai` to enable layout generation"
+        )
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise LayoutGenerationError(
+            "OPENAI_API_KEY is not set in the environment; export a key before running"
+        )
+
+    try:
+        return OpenAI(api_key=api_key)
+    except Exception as exc:  # pragma: no cover - network configuration issues
+        raise LayoutGenerationError("failed to initialise OpenAI client") from exc
+
+
+def call_openai_layout(software_title: str) -> Dict[str, Any]:
+    """Request a layout suggestion from the OpenAI API."""
+
+    client = _build_openai_client()
+
+    prompt = textwrap.dedent(
+        f"""
+        You are designing pages for an Elgato Stream Deck XL (8x4 grid).
+        Return JSON with a `pages` list where each page has a `name` and a
+        `buttons` list. Every button requires `col`, `row`, `title`, and
+        `action` fields. Reserve column 0, row 3 on every non-master page for
+        an RTB button that navigates back to the Master page. Reserve column 7,
+        row 3 on the Master page for a button that switches to the Default
+        profile. Software title: {software_title}.
+        """
+    ).strip()
+
+    try:
+        response = client.responses.create(  # type: ignore[attr-defined]
+            model=os.getenv("OPENAI_MODEL", "gpt-4.1-mini"),
+            input=prompt,
+            response_format={"type": "json_object"},
+        )
+    except Exception as exc:
+        raise LayoutGenerationError("OpenAI layout request failed") from exc
+
+    try:
+        content = response.output[0].content[0].text  # type: ignore[index]
+        return cast(Dict[str, Any], json.loads(content))
+    except Exception as exc:
+        raise LayoutGenerationError("OpenAI layout response was not valid JSON") from exc
+
+
+# ---------------------------------------------------------------------------
+# Layout sanitising
+# ---------------------------------------------------------------------------
+
+def sanitize_pages(ai_response: Dict[str, Any]) -> List[Page]:
+    """Normalise an AI layout response into Page objects."""
+
+    if "pages" not in ai_response:
+        raise LayoutGenerationError("OpenAI response did not include a `pages` field")
+
+    pages: List[Page] = []
+
+    for page_data in ai_response.get("pages", []):
+        name = str(page_data.get("name", "Custom"))
+        button_grid: Dict[int, Button] = {}
+
+        for raw_button in page_data.get("buttons", []):
+            try:
+                col = max(0, min(GRID_COLS - 1, int(raw_button.get("col", 0))))
+                row = max(0, min(GRID_ROWS - 1, int(raw_button.get("row", 0))))
+                title = str(raw_button.get("title", "")).strip()[:16] or "—"
+                action = str(raw_button.get("action", "noop")).strip() or "noop"
+                idx = row * GRID_COLS + col
+                button_grid[idx] = Button(col, row, title, action)
+            except Exception:
+                continue
+
+        buttons: List[Button] = []
+        for idx in range(BUTTONS_PER_PAGE):
+            col = idx % GRID_COLS
+            row = idx // GRID_COLS
+            if idx in button_grid:
+                buttons.append(button_grid[idx])
+            elif name != "Master" and col == 0 and row == 3:
+                buttons.append(Button(col, row, "RTB", "switch_page:Master"))
+            elif name == "Master" and col == 7 and row == 3:
+                buttons.append(Button(col, row, "Default", "profile:Default"))
+            else:
+                buttons.append(Button(col, row, "—", "noop"))
+
+        pages.append(Page(name, buttons))
+
+    if not pages:
+        raise LayoutGenerationError("OpenAI response did not define any pages")
+
+    if not any(page.name == "Master" for page in pages):
+        raise LayoutGenerationError("OpenAI response omitted a Master page")
+
+    return pages
+
+
+def build_profile_pages(software_title: str) -> List[Page]:
+    """Resolve pages via OpenAI or raise if the request cannot be satisfied."""
+
+    ai_layout = call_openai_layout(software_title)
+    return sanitize_pages(ai_layout)

--- a/streamdeck_profile_generator/models.py
+++ b/streamdeck_profile_generator/models.py
@@ -1,0 +1,38 @@
+"""Domain models for Stream Deck profile generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+GRID_COLS = 8
+GRID_ROWS = 4
+BUTTONS_PER_PAGE = GRID_COLS * GRID_ROWS
+
+
+@dataclass
+class Button:
+    """Represents a single Stream Deck button."""
+
+    col: int
+    row: int
+    title: str
+    action: str
+    icon: Optional[str] = None
+    tooltip: Optional[str] = None
+
+
+@dataclass
+class Page:
+    """Represents a Stream Deck page (folder) of buttons."""
+
+    name: str
+    buttons: List[Button]
+
+
+@dataclass
+class Profile:
+    """Holds the generated profile metadata."""
+
+    software_title: str
+    pages: List[Page]

--- a/streamdeck_profile_generator/packaging.py
+++ b/streamdeck_profile_generator/packaging.py
@@ -1,0 +1,145 @@
+"""Profile packaging utilities for Stream Deck."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import zipfile
+from typing import Dict, Iterable, List
+
+from .icons import render_icons
+from .models import Button, Page, Profile
+
+
+def create_streamdeck_profile(profile: Profile, output_basename: str) -> str:
+    """Create a `.streamDeckProfile` archive from the supplied profile."""
+
+    temp_dir = tempfile.mkdtemp(prefix="streamdeck_")
+
+    try:
+        icons_dir = os.path.join(temp_dir, "Icons")
+        render_icons(profile.pages, icons_dir)
+
+        manifest = _build_manifest(profile)
+
+        with open(os.path.join(temp_dir, "manifest.json"), "w", encoding="utf-8") as manifest_file:
+            json.dump(manifest, manifest_file, indent=2)
+
+        archive_path = f"{output_basename}.streamDeckProfile"
+        if os.path.exists(archive_path):
+            os.remove(archive_path)
+
+        with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            for root, _, files in os.walk(temp_dir):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    archive.write(file_path, os.path.relpath(file_path, temp_dir))
+
+        return archive_path
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def _build_manifest(profile: Profile) -> Dict[str, object]:
+    """Create a Stream Deck 7 manifest payload."""
+
+    manifest: Dict[str, object] = {
+        "Actions": {},
+        "Author": "StreamDeck Profile Generator",
+        "Category": "Automation",
+        "CategoryIcon": "",
+        "Description": f"StreamDeck profile for {profile.software_title}",
+        "Name": f"{profile.software_title} Profile",
+        "Version": "1.0.0",
+        "DeviceType": 7,
+        "Icon": "",
+        "URL": "",
+        "OS": [{"Platform": "windows", "MinimumVersion": "10"}],
+        "Software": {"MinimumVersion": "6.0"},
+        "ApplicationsToMonitor": {
+            "windows": _candidate_executables(profile.software_title),
+        },
+        "Profiles": [
+            {
+                "Name": f"{profile.software_title} Profile",
+                "DeviceType": 7,
+                "Pages": [],
+            }
+        ],
+    }
+
+    pages_payload = manifest["Profiles"][0]["Pages"]  # type: ignore[index]
+
+    for page in profile.pages:
+        page_payload: Dict[str, object] = {"Name": page.name, "Buttons": {}}
+        page_payload["Buttons"].update(_serialise_buttons(page.buttons))  # type: ignore[index]
+        pages_payload.append(page_payload)  # type: ignore[arg-type]
+
+    return manifest
+
+
+def _candidate_executables(software_title: str) -> List[str]:
+    """Produce executable name candidates for Stream Deck monitoring."""
+
+    slug = software_title.lower().replace(" ", "")
+    underscored = software_title.replace(" ", "_")
+    return [
+        f"{slug}.exe",
+        f"{underscored}.exe",
+        f"{software_title}.exe",
+    ]
+
+
+def _serialise_buttons(buttons: Iterable[Button]) -> Dict[str, object]:
+    """Convert non-empty buttons into Stream Deck manifest entries."""
+
+    serialised: Dict[str, object] = {}
+
+    for button in buttons:
+        if button.action == "noop" or button.title == "—":
+            continue
+
+        button_key = f"{button.col},{button.row}"
+        button_payload: Dict[str, object] = {
+            "Name": button.title,
+            "State": 0,
+            "States": [
+                {
+                    "Image": f"Icons/{button.icon}" if button.icon else "",
+                    "Title": button.title,
+                    "TitleAlignment": "middle",
+                    "FontSize": "16",
+                }
+            ],
+        }
+
+        action = button.action
+        if action.startswith("hotkey:"):
+            button_payload.update(
+                {
+                    "UUID": "com.elgato.streamdeck.system.hotkey",
+                    "Settings": {"Hotkey": action.replace("hotkey:", "", 1)},
+                }
+            )
+        elif action.startswith("run:"):
+            button_payload.update(
+                {
+                    "UUID": "com.elgato.streamdeck.system.open",
+                    "Settings": {"Path": action.replace("run:", "", 1)},
+                }
+            )
+        elif action.startswith("switch_page:") or action.startswith("profile:"):
+            button_payload.update(
+                {
+                    "UUID": "com.elgato.streamdeck.system.profile",
+                    "Settings": {"ProfileUUID": "", "ProfileName": action.split(":", 1)[1]},
+                }
+            )
+        else:
+            button_payload.update({"UUID": "com.elgato.streamdeck.system.blank", "Settings": {}})
+
+        serialised[button_key] = button_payload
+
+    return serialised

--- a/streamdeck_profile_generator/requirements.txt
+++ b/streamdeck_profile_generator/requirements.txt
@@ -1,0 +1,15 @@
+# ============================================================================
+# Stream Deck Profile Generator Dependencies
+# ----------------------------------------------------------------------------
+# This list only covers the packages required to run the Stream Deck generator
+# CLI.  Project-wide dependencies live in the root-level requirements.txt that
+# supports the broader AESTHETIC application.
+# ============================================================================
+
+# --- API + layout generation -------------------------------------------------
+# The OpenAI SDK supplies the "OpenAI" client used during layout planning.
+openai>=1.0.0
+
+# --- Icon rendering ----------------------------------------------------------
+# Pillow renders the 72x72 PNG button icons written into each profile archive.
+pillow>=10.0.0


### PR DESCRIPTION
## Summary
- remove the deterministic fallback path so layout resolution always uses OpenAI
- keep layout sanitisation unchanged to validate the AI response before building pages

## Testing
- ⚠️ `python -m streamdeck_profile_generator.cli "Test App"` *(fails until the OpenAI package and API key are configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d76e17da08832799569bcf9bf34846